### PR TITLE
fix: support native fullscreen with window-decorations=none on macOS

### DIFF
--- a/macos/Sources/Ghostty/Ghostty.App.swift
+++ b/macos/Sources/Ghostty/Ghostty.App.swift
@@ -576,7 +576,7 @@ extension Ghostty {
             case GHOSTTY_ACTION_TOGGLE_TAB_OVERVIEW:
                 fallthrough
             case GHOSTTY_ACTION_TOGGLE_WINDOW_DECORATIONS:
-                fallthrough
+                toggleWindowDecorations(app, target: target)
             case GHOSTTY_ACTION_PRESENT_TERMINAL:
                 fallthrough
             case GHOSTTY_ACTION_SIZE_LIMIT:
@@ -1201,6 +1201,26 @@ extension Ghostty {
                 if let appDelegate = NSApplication.shared.delegate as? AppDelegate {
                     appDelegate.syncFloatOnTopMenu(window)
                 }
+
+            default:
+                assertionFailure()
+            }
+        }
+
+        private static func toggleWindowDecorations(
+            _ app: ghostty_app_t,
+            target: ghostty_target_s
+        ) {
+            switch (target.tag) {
+            case GHOSTTY_TARGET_APP:
+                Ghostty.logger.warning("toggle window decorations does nothing with an app target")
+                return
+
+            case GHOSTTY_TARGET_SURFACE:
+                guard let surface = target.target.surface else { return }
+                guard let surfaceView = self.surfaceView(from: surface) else { return }
+                guard let terminalController = surfaceView.window?.windowController as? BaseTerminalController else { return }
+                terminalController.toggleWindowDecorations()
 
             default:
                 assertionFailure()


### PR DESCRIPTION
This PR fixes an issue where native fullscreen mode doesn't work properly when \`window-decorations=none\` is configured.

## Changes
- Save the window decoration state before entering native fullscreen
- Temporarily enable decorations during native fullscreen (required by macOS)
- Restore the original decoration state when exiting fullscreen

## Background
Native fullscreen on macOS requires window decorations to function properly. When users have \`window-decorations=none\` configured, entering native fullscreen would fail or behave incorrectly. This fix ensures compatibility by managing the decoration state automatically during fullscreen transitions.

## Testing
- Configure \`window-decorations=none\`
- Enter/exit native fullscreen mode
- Verify decorations are properly restored after exiting fullscreen