### PR TITLE
feat: add toggle window decorations action for macOS

### DIFF
--- a/macos/Sources/Features/Terminal/BaseTerminalController.swift
+++ b/macos/Sources/Features/Terminal/BaseTerminalController.swift
@@ -790,6 +790,22 @@ class BaseTerminalController: NSWindowController,
 
     func fullscreenDidChange() {}
 
+    // MARK: Window Decorations
+
+    /// Toggle window decorations for this window
+    func toggleWindowDecorations() {
+        guard let window = self.window as? TerminalWindow else { return }
+        
+        // Toggle the style mask to enable/disable decorations
+        if window.styleMask.contains(.titled) {
+            // Remove decorations (make window borderless)
+            window.styleMask.remove(.titled)
+        } else {
+            // Add decorations back
+            window.styleMask.insert(.titled)
+        }
+    }
+
     // MARK: Clipboard Confirmation
 
     @objc private func onConfirmClipboardRequest(notification: SwiftUI.Notification) {

--- a/macos/Sources/Ghostty/Ghostty.App.swift
+++ b/macos/Sources/Ghostty/Ghostty.App.swift
@@ -576,7 +576,7 @@ extension Ghostty {
             case GHOSTTY_ACTION_TOGGLE_TAB_OVERVIEW:
                 fallthrough
             case GHOSTTY_ACTION_TOGGLE_WINDOW_DECORATIONS:
-                fallthrough
+                toggleWindowDecorations(app, target: target)
             case GHOSTTY_ACTION_PRESENT_TERMINAL:
                 fallthrough
             case GHOSTTY_ACTION_SIZE_LIMIT:
@@ -1247,6 +1247,26 @@ extension Ghostty {
         ) {
             guard let appDelegate = NSApplication.shared.delegate as? AppDelegate else { return }
             appDelegate.toggleQuickTerminal(self)
+        }
+
+        private static func toggleWindowDecorations(
+            _ app: ghostty_app_t,
+            target: ghostty_target_s
+        ) {
+            switch (target.tag) {
+            case GHOSTTY_TARGET_APP:
+                Ghostty.logger.warning("toggle window decorations does nothing with an app target")
+                return
+
+            case GHOSTTY_TARGET_SURFACE:
+                guard let surface = target.target.surface else { return }
+                guard let surfaceView = self.surfaceView(from: surface) else { return }
+                guard let terminalController = surfaceView.window?.windowController as? BaseTerminalController else { return }
+                terminalController.toggleWindowDecorations()
+
+            default:
+                assertionFailure()
+            }
         }
 
         private static func setTitle(


### PR DESCRIPTION
This PR adds a new action to toggle window decorations (titlebar) on and off for macOS.

## Changes
- Add \`toggleWindowDecorations()\` method to \`BaseTerminalController\`
- Implement action handler for \`GHOSTTY_ACTION_TOGGLE_WINDOW_DECORATIONS\`
- Toggle between titled and borderless window styles

## Usage
Users can now bind the \`toggle_window_decorations\` action to a key combination to dynamically show/hide the window titlebar and decorations.

## Implementation Details
- Uses NSWindow's \`styleMask\` to add/remove the \`.titled\` style
- Works by checking current state and toggling the opposite
- Integrated with the existing Ghostty action system

## Testing
- Bind \`toggle_window_decorations\` to a key
- Verify titlebar toggles on/off when action is triggered
- Test with various window states (fullscreen, tabbed, etc.)